### PR TITLE
set request _locale attribute breaks the switcher.

### DIFF
--- a/Controller/LocaleController.php
+++ b/Controller/LocaleController.php
@@ -69,8 +69,10 @@ class LocaleController
             throw new \InvalidArgumentException(sprintf('Not allowed to switch to locale %s', $_locale));
         }
 
-        $localeSwitchEvent = new FilterLocaleSwitchEvent($request, $_locale);
-        $this->dispatcher->dispatch(LocaleBundleEvents::onLocaleChange, $localeSwitchEvent);
+        if ($this->dispatcher !== null) {
+            $localeSwitchEvent = new FilterLocaleSwitchEvent($request, $_locale);
+            $this->dispatcher->dispatch(LocaleBundleEvents::onLocaleChange, $localeSwitchEvent);
+        }
 
         // Redirect the User
         if ($useReferrer && $request->headers->has('referer')) {

--- a/Controller/LocaleController.php
+++ b/Controller/LocaleController.php
@@ -39,7 +39,7 @@ class LocaleController
      * @param null            $redirectToRoute From Config
      * @param string          $statusCode      From Config
      */
-    public function __construct(RouterInterface $router = null, MetaValidator $metaValidator, $useReferrer = true, $redirectToRoute = null, $statusCode = '302', EventDispatcherInterface $dispatcher)
+    public function __construct(RouterInterface $router = null, MetaValidator $metaValidator, $useReferrer = true, $redirectToRoute = null, $statusCode = '302', EventDispatcherInterface $dispatcher = null)
     {
         $this->router = $router;
         $this->metaValidator = $metaValidator;

--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -110,7 +110,7 @@ class LocaleListener implements EventSubscriberInterface
         if ($locale) {
             $this->logEvent('Setting [ %s ] as locale for the (Sub-)Request', $locale);
             $request->setLocale($locale);
-            $request->attributes->set('_locale', $locale);
+//            $request->attributes->set('_locale', $locale);
 
             if (($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST || $request->isXmlHttpRequest())
                 && ($manager->getGuesser('session') || $manager->getGuesser('cookie'))

--- a/Resources/config/switcher.xml
+++ b/Resources/config/switcher.xml
@@ -28,6 +28,7 @@
             <argument>%lunetics_locale.switcher.use_referrer%</argument>
             <argument>%lunetics_locale.switcher.redirect_to_route%</argument>
             <argument>%lunetics_locale.switcher.redirect_statuscode%</argument>
+            <argument type="service" id="event_dispatcher" />
         </service>
 
     </services>


### PR DESCRIPTION
to reproduce:
Let assume we didn't comment proposed PR
Add to LocaleController->switchAction after setting $redirectToRoute next lines :

```
dump($request);
dump($_locale);
die();
```

config settings next:

```
lunetics_locale:
    strict_mode: true
    allowed_locales:
        - zh
        - en
    guessing_order:
        - session
        - cookie
        - browser
        - query
        - router
    switcher:
        use_controller: true
    cookie:
        set_on_change: true
```

and try to change the locale with switcher. Assume we changing the locale by next url: ..../changeLocale/cc
the result will be:

```
LocaleController.php on line 61:
Request {#7 ▼
  +attributes: ParameterBag {#10 ▶}
  +request: ParameterBag {#8 ▶}
  +query: ParameterBag {#9 ▶}
  +server: ServerBag {#13 ▶}
  +files: FileBag {#12 ▶}
  +cookies: ParameterBag {#11 ▶}
  +headers: HeaderBag {#14 ▶}
  #content: null
  #languages: array:2 [▶]
  #charsets: null
  #encodings: null
  #acceptableContentTypes: null
  #pathInfo: "/changeLocale/cc"
  #requestUri: "/changeLocale/cc"
  #baseUrl: ""
  #basePath: null
  #method: "GET"
  #format: null
  #session: Session {#504 ▶}
  #locale: "en"
  #defaultLocale: "zh_CN"
}
LocaleController.php on line 62:
"en"
```

SO, locale change was not picked,
but if we do comment proposed PR, the result for the same query is:

```
LocaleController.php on line 61:
Request {#7 ▼
  +attributes: ParameterBag {#10 ▶}
  +request: ParameterBag {#8 ▶}
  +query: ParameterBag {#9 ▶}
  +server: ServerBag {#13 ▶}
  +files: FileBag {#12 ▶}
  +cookies: ParameterBag {#11 ▶}
  +headers: HeaderBag {#14 ▶}
  #content: null
  #languages: array:2 [▶]
  #charsets: null
  #encodings: null
  #acceptableContentTypes: null
  #pathInfo: "/changeLocale/cc"
  #requestUri: "/changeLocale/cc"
  #baseUrl: ""
  #basePath: null
  #method: "GET"
  #format: null
  #session: Session {#504 ▶}
  #locale: "cc"
  #defaultLocale: "zh_CN"
}
LocaleController.php on line 62:
"cc"
```
